### PR TITLE
Addition of character encoding detection and keyring

### DIFF
--- a/chrome_cookiejar/decrypt.py
+++ b/chrome_cookiejar/decrypt.py
@@ -13,9 +13,15 @@ else:
         if not cipher_blob:
             return cipher_blob
         elif cipher_blob.startswith(b'v10'):
-            password = b'peanuts'
+            if sys.platform == 'darwin':
+                password = get_chrome_safe_storage()
+            else:
+                password = b'peanuts'.encode('utf-8')
         elif cipher_blob.startswith(b'v11'):
             password = get_chrome_safe_storage()
         else:
             raise ValueError('Unknown cipher type: %r' % cipher_blob)
-        return aes_cbc_decrypt(cipher_blob, password)
+        if sys.platform == 'darwin':
+            return aes_cbc_decrypt(cipher_blob, password, iterations=1003)
+        else:
+            return aes_cbc_decrypt(cipher_blob, password)

--- a/chrome_cookiejar/main.py
+++ b/chrome_cookiejar/main.py
@@ -1,3 +1,4 @@
+import chardet
 import datetime
 import http.cookiejar
 import sqlite3
@@ -46,7 +47,12 @@ class ChromeCookieJar(http.cookiejar.CookieJar):
                 if 'encrypted_value' in row:
                     encrypted_value = row.pop('encrypted_value')
                     if not row.get('value'):
-                        row['value'] = decrypt(encrypted_value).decode()
+                        decrypted_value = decrypt(encrypted_value)
+                        encoding = chardet.detect(decrypted_value)['encoding']
+                        if encoding:
+                            row['value'] = decrypted_value.decode(encoding)
+                        else:
+                            row['value'] = decrypted_value.decode()
                 self.set_cookie(http.cookiejar.Cookie(
                     **row, **dummy, version=0,  # typing: ignore
                 ))

--- a/chrome_cookiejar/unix_crypt.py
+++ b/chrome_cookiejar/unix_crypt.py
@@ -1,3 +1,4 @@
+import keyring
 from Crypto.Cipher import AES
 from Crypto.Protocol.KDF import PBKDF2
 
@@ -22,4 +23,5 @@ def aes_cbc_decrypt(
 
 
 def get_chrome_safe_storage() -> bytes:
-    raise NotImplementedError
+    my_pass = keyring.get_password('Chrome Safe Storage', 'Chrome')
+    return my_pass.encode('utf8')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
     "chardet",
+    "keyring",
     "setuptools>=42",
     "wheel"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = [
+    "chardet",
     "setuptools>=42",
     "wheel"
 ]


### PR DESCRIPTION
Thought I'd offer up a few things I've found handy while playing with `chrome-cookiejar` on OS X.

- The addition of the `chardet` module for helping auto-detect character encodings for cookies.
- The addition of the `keyring` module to get the `Chrome Safe Storage` storage password from the OS X keychain.
  - Also tweaked the number of iterations on chrome per [this article](https://n8henrie.com/2014/05/decrypt-chrome-cookies-with-python/)
- The ability to specify which cookies to return by name

Let me know if anything needs tweaking! 